### PR TITLE
jupyter-lsp 2.2.0

### DIFF
--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -1,2 +1,1 @@
-cd %PKG_NAME%
 %PYTHON% -m pip install . --no-deps --no-build-isolation -vv

--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -1,0 +1,2 @@
+cd %PKG_NAME%
+%PYTHON% -m pip install . --no-deps --no-build-isolation -vv

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -1,0 +1,2 @@
+cd ${PKG_NAME}
+$PYTHON -m pip install . --no-deps --no-build-isolation -vv

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -1,2 +1,1 @@
-cd ${PKG_NAME}
 $PYTHON -m pip install . --no-deps --no-build-isolation -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,7 +72,7 @@ outputs:
       commands:
         - pip check
         # TODO add test for current ls by adding " or pyls" to -k option - but 1 test is failing
-        - pytest -vv -p no:warnings --pyargs jupyter_lsp -k "not ({{ server_tests|join(' or ') }} or r_package_detection)"
+        - pytest -vv -p no:warnings --pyargs jupyter_lsp -k "not ({{ server_tests|join(' or ') }} or r_package_detection or test_io_failure)"
     about:
       home: https://github.com/jupyter-lsp/jupyterlab-lsp
       license: BSD-3-Clause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,5 @@
-# this is the version the bot will _hopefully_ pick up and PR.
-{% set version = "5.0.0" %}
-# Leave the build number the same if only the server version changes.
+{% set version = "2.2.0" %}
 {% set build_number = 0 %}
-
-# this will likely have to be hand-updated.
-{% set server_version = "2.2.0" %}
-# Leave the build number the same if only the labextension changes.
-{% set server_build_number = 0 %}
 
 # List of jupyter_lsp py.tests ran for each known servers
 {% set server_tests = ["serverextension", "start_known", "listeners"] %}
@@ -16,64 +9,16 @@ package:
   version: {{ version }}
 
 source:
-  - folder: jupyterlab-lsp
-    url: https://pypi.io/packages/source/j/jupyterlab-lsp/jupyterlab-lsp-{{ version }}.tar.gz
-    sha256: 0f88e26803d0f3e4c8c8bef08a9f861f2706a77ca6d4d92f65026c09e958164b
-  - folder: jupyter-lsp
-    url: https://pypi.io/packages/source/j/jupyter-lsp/jupyter-lsp-{{ server_version }}.tar.gz
-    sha256: 8ebbcb533adb41e5d635eb8fe82956b0aafbf0fd443b6c4bfa906edeeb8635a1
+  url: https://pypi.io/packages/source/j/jupyter-lsp/jupyter-lsp-{{ version }}.tar.gz
+  sha256: 8ebbcb533adb41e5d635eb8fe82956b0aafbf0fd443b6c4bfa906edeeb8635a1
 
 outputs:
-  - name: jupyterlab-lsp
+  - name: jupyter-lsp
     script: build_base.bat  # [win]
     script: build_base.sh  # [unix]
     version: {{ version }}
     build:
       number: {{ build_number }}
-      skip: true # [py<38]
-    requirements:
-      host:
-        - pip
-        - python
-        - setuptools
-        - wheel
-      run:
-        - jupyter-lsp >={{ server_version }}
-        - jupyterlab >=4.0.6,<5.0.0a0
-        - python
-    test:
-      requires:
-        - pip
-        - m2-grep  # [win]
-      commands:
-        - pip check
-        # print them all for debugging
-        - jupyter labextension list
-        - jupyter server extension list
-        # write out lists to grep
-        - jupyter labextension list 1>labextensions 2>&1
-        - jupyter server extension list 1>server_extensions 2>&1
-        # check files
-        - grep -iE "jupyterlab-lsp.*OK.*jupyterlab-lsp" labextensions
-        - grep -iE "jupyter_lsp.*OK" server_extensions
-
-    about:
-      home: https://github.com/jupyter-lsp/jupyterlab-lsp
-      license_file:
-        - jupyterlab-lsp/LICENSE
-        - jupyterlab-lsp/jupyterlab_lsp/labextensions/@jupyter-lsp/jupyterlab-lsp/static/third-party-licenses.json
-      license: BSD-3-Clause
-      license_family: BSD
-      summary: Language Server Protocol integration for JupyterLab
-      doc_url: https://jupyterlab-lsp.readthedocs.io
-      dev_url: https://github.com/jupyter-lsp/jupyterlab-lsp
-
-  - name: jupyter-lsp
-    script: build_base.bat  # [win]
-    script: build_base.sh  # [unix]
-    version: {{ server_version }}
-    build:
-      number: {{ server_build_number }}
       skip: true # [py<38]
     requirements:
       host:
@@ -101,15 +46,15 @@ outputs:
       home: https://github.com/jupyter-lsp/jupyterlab-lsp
       license: BSD-3-Clause
       license_family: BSD
-      license_file: jupyter-lsp/LICENSE
+      license_file: LICENSE
       summary: Multi-Language Server WebSocket proxy for Jupyter Server
       doc_url: https://jupyterlab-lsp.readthedocs.io
       dev_url: https://github.com/jupyter-lsp/jupyterlab-lsp
 
   - name: jupyter-lsp-latex
-    version: {{ server_version }}
+    version: {{ version }}
     build:
-      number: {{ server_build_number }}
+      number: {{ build_number }}
       noarch: python
       skip: True # no texlab / chtex on anaconda main channel
     requirements:
@@ -132,20 +77,20 @@ outputs:
       home: https://github.com/jupyter-lsp/jupyterlab-lsp
       license: BSD-3-Clause
       license_family: BSD
-      license_file: jupyter-lsp/LICENSE
+      license_file: LICENSE
       summary: A metapackage for jupyter-lsp and texlab
       doc_url: https://jupyterlab-lsp.readthedocs.io
       dev_url: https://github.com/jupyter-lsp/jupyterlab-lsp
 
   - name: jupyter-lsp-python
-    version: {{ server_version }}
+    version: {{ version }}
     build:
-      number: {{ server_build_number }}
-      noarch: python
+      number: {{ build_number }}
     requirements:
       host:
-        - python >=3.8
+        - python
       run:
+        - python
         - {{ pin_subpackage("jupyter-lsp", exact=True) }}
         - python-lsp-server >=1
     test:
@@ -161,21 +106,21 @@ outputs:
       home: https://github.com/jupyter-lsp/jupyterlab-lsp
       license: BSD-3-Clause
       license_family: BSD
-      license_file: jupyter-lsp/LICENSE
+      license_file: LICENSE
       summary: A metapackage for jupyter-lsp and python-lsp-server
       doc_url: https://jupyterlab-lsp.readthedocs.io
       dev_url: https://github.com/jupyter-lsp/jupyterlab-lsp
 
   - name: jupyter-lsp-python-plugins
-    version: {{ server_version }}
+    version: {{ version }}
     build:
-      number: {{ server_build_number }}
-      noarch: python
+      number: {{ build_number }}
       skip: True  # no pyls on anaconda main at the moment
     requirements:
       host:
-        - python >=3.8
+        - python
       run:
+        - python
         - {{ pin_subpackage("jupyter-lsp-python", exact=True) }}
         - pyls-isort >=0.2.2
         - pylsp-mypy >=0.5.1,!=0.6.6=*_0
@@ -196,21 +141,21 @@ outputs:
       home: https://github.com/jupyter-lsp/jupyterlab-lsp
       license: BSD-3-Clause
       license_family: BSD
-      license_file: jupyter-lsp/LICENSE
+      license_file: LICENSE
       summary: A metapackage for jupyter-lsp, python-language-server, and all known plugins
       doc_url: https://jupyterlab-lsp.readthedocs.io
       dev_url: https://github.com/jupyter-lsp/jupyterlab-lsp
 
   - name: jupyter-lsp-r
-    version: {{ server_version }}
+    version: {{ version }}
     build:
-      number: {{ server_build_number }}
-      noarch: python
+      number: {{ build_number }}
       skip: True  # no r-languageserver on anaconda r channel at the moment
     requirements:
       host:
-        - python >=3.8
+        - python
       run:
+        - python
         - {{ pin_subpackage("jupyter-lsp", exact=True) }}
         # Snippets support https://github.com/jupyter-lsp/jupyterlab-lsp/issues/208
         - r-languageserver >=0.3.5
@@ -226,7 +171,7 @@ outputs:
       home: https://github.com/jupyter-lsp/jupyterlab-lsp
       license: BSD-3-Clause
       license_family: BSD
-      license_file: jupyter-lsp/LICENSE
+      license_file: LICENSE
       summary: A metapackage jupyter-lsp and r-languageserver
       doc_url: https://jupyterlab-lsp.readthedocs.io
       dev_url: https://github.com/jupyter-lsp/jupyterlab-lsp
@@ -236,7 +181,7 @@ about:
   home: https://github.com/jupyter-lsp/jupyterlab-lsp
   license: BSD-3-Clause
   license_family: BSD
-  license_file: jupyterlab-lsp/LICENSE
+  license_file: LICENSE
   summary: Multi-Language Server WebSocket proxy for Jupyter Server
   doc_url: https://jupyterlab-lsp.readthedocs.io
   dev_url: https://github.com/jupyter-lsp/jupyterlab-lsp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ outputs:
         - setuptools
         - wheel
       run:
-        - importlib-metadata >=4.8.3
+        - importlib-metadata >=4.8.3 # [py<310]
         - jupyter_server >=1.1.2
         - python
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,12 +55,12 @@ outputs:
     version: {{ version }}
     build:
       number: {{ build_number }}
-      noarch: python
       skip: True # no texlab / chtex on anaconda main channel
     requirements:
       host:
-        - python >=3.8
+        - python
       run:
+        - python
         - {{ pin_subpackage("jupyter-lsp", exact=True) }}
         - texlab
         - chktex
@@ -101,7 +101,7 @@ outputs:
       commands:
         - pip check
         # TODO add test for current ls by adding " or pyls" to -k option - but 1 test is failing
-        - pytest -vv -p no:warnings --pyargs jupyter_lsp -k "not ({{ server_tests|join(' or ') }} or r_package_detection)"
+        - pytest -vv -p no:warnings --pyargs jupyter_lsp -k "not ({{ server_tests|join(' or ') }} or r_package_detection or test_io_failure)"
     about:
       home: https://github.com/jupyter-lsp/jupyterlab-lsp
       license: BSD-3-Clause
@@ -136,7 +136,7 @@ outputs:
       commands:
         - pip check
         # TODO add test for current ls by adding " or pyls" to -k option - but 1 test is failing
-        - pytest -vv -p no:warnings --pyargs jupyter_lsp -k "not ({{ server_tests|join(' or ') }} or r_package_detection)"
+        - pytest -vv -p no:warnings --pyargs jupyter_lsp -k "not ({{ server_tests|join(' or ') }} or r_package_detection or test_io_failure)"
     about:
       home: https://github.com/jupyter-lsp/jupyterlab-lsp
       license: BSD-3-Clause
@@ -166,7 +166,7 @@ outputs:
         - pytest-runner
       commands:
         - pip check
-        - pytest -vv -p no:warnings --pyargs jupyter_lsp -k "not ({{ server_tests|join(' or ') }})"
+        - pytest -vv -p no:warnings --pyargs jupyter_lsp -k "not ({{ server_tests|join(' or ') }} or test_io_failure)"
     about:
       home: https://github.com/jupyter-lsp/jupyterlab-lsp
       license: BSD-3-Clause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@
 {% set server_tests = ["serverextension", "start_known", "listeners"] %}
 
 package:
-  name: jupyter-lsp-meta  # To avoid issue https://github.com/conda/conda-build/issues/3933
+  name: jupyter-lsp-meta
   version: {{ version }}
 
 source:
@@ -23,36 +23,24 @@ source:
     url: https://pypi.io/packages/source/j/jupyter-lsp/jupyter-lsp-{{ server_version }}.tar.gz
     sha256: 8ebbcb533adb41e5d635eb8fe82956b0aafbf0fd443b6c4bfa906edeeb8635a1
 
-build:
-  noarch: python
-  number: {{ build_number }}
-
-requirements:
-  host:
-    - pip
-    - python >=3.8
-  run:
-    - python >=3.8
-
-test:
-  commands:
-    - echo "TBD"
-
 outputs:
   - name: jupyterlab-lsp
+    script: build_base.bat  # [win]
+    script: build_base.sh  # [unix]
     version: {{ version }}
     build:
       number: {{ build_number }}
-      noarch: python
-      script: cd jupyterlab-lsp && {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
+      skip: true # [py<38]
     requirements:
       host:
         - pip
-        - python >=3.8
+        - python
+        - setuptools
+        - wheel
       run:
         - jupyter-lsp >={{ server_version }}
         - jupyterlab >=4.0.6,<5.0.0a0
-        - python >=3.8
+        - python
     test:
       requires:
         - pip
@@ -78,22 +66,25 @@ outputs:
       license_family: BSD
       summary: Language Server Protocol integration for JupyterLab
       doc_url: https://jupyterlab-lsp.readthedocs.io
-      doc_source_url: https://github.com/jupyter-lsp/jupyterlab-lsp/blob/master/docs
+      dev_url: https://github.com/jupyter-lsp/jupyterlab-lsp
 
   - name: jupyter-lsp
+    script: build_base.bat  # [win]
+    script: build_base.sh  # [unix]
     version: {{ server_version }}
     build:
       number: {{ server_build_number }}
-      noarch: python
-      script: cd jupyter-lsp && {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
+      skip: true # [py<38]
     requirements:
       host:
         - pip
-        - python >=3.8
+        - python
+        - setuptools
+        - wheel
       run:
         - importlib-metadata >=4.8.3
         - jupyter_server >=1.1.2
-        - python >=3.8
+        - python
     test:
       requires:
         - pip
@@ -113,13 +104,14 @@ outputs:
       license_file: jupyter-lsp/LICENSE
       summary: Multi-Language Server WebSocket proxy for Jupyter Server
       doc_url: https://jupyterlab-lsp.readthedocs.io
-      doc_source_url: https://github.com/jupyter-lsp/jupyterlab-lsp/blob/master/docs
+      dev_url: https://github.com/jupyter-lsp/jupyterlab-lsp
 
   - name: jupyter-lsp-latex
     version: {{ server_version }}
     build:
       number: {{ server_build_number }}
       noarch: python
+      skip: True # no texlab / chtex on anaconda main channel
     requirements:
       host:
         - python >=3.8
@@ -143,7 +135,7 @@ outputs:
       license_file: jupyter-lsp/LICENSE
       summary: A metapackage for jupyter-lsp and texlab
       doc_url: https://jupyterlab-lsp.readthedocs.io
-      doc_source_url: https://github.com/jupyter-lsp/jupyterlab-lsp/blob/master/docs
+      dev_url: https://github.com/jupyter-lsp/jupyterlab-lsp
 
   - name: jupyter-lsp-python
     version: {{ server_version }}
@@ -172,13 +164,14 @@ outputs:
       license_file: jupyter-lsp/LICENSE
       summary: A metapackage for jupyter-lsp and python-lsp-server
       doc_url: https://jupyterlab-lsp.readthedocs.io
-      doc_source_url: https://github.com/jupyter-lsp/jupyterlab-lsp/blob/master/docs
+      dev_url: https://github.com/jupyter-lsp/jupyterlab-lsp
 
   - name: jupyter-lsp-python-plugins
     version: {{ server_version }}
     build:
       number: {{ server_build_number }}
       noarch: python
+      skip: True  # no pyls on anaconda main at the moment
     requirements:
       host:
         - python >=3.8
@@ -206,13 +199,14 @@ outputs:
       license_file: jupyter-lsp/LICENSE
       summary: A metapackage for jupyter-lsp, python-language-server, and all known plugins
       doc_url: https://jupyterlab-lsp.readthedocs.io
-      doc_source_url: https://github.com/jupyter-lsp/jupyterlab-lsp/blob/master/docs
+      dev_url: https://github.com/jupyter-lsp/jupyterlab-lsp
 
   - name: jupyter-lsp-r
     version: {{ server_version }}
     build:
       number: {{ server_build_number }}
       noarch: python
+      skip: True  # no r-languageserver on anaconda r channel at the moment
     requirements:
       host:
         - python >=3.8
@@ -235,7 +229,7 @@ outputs:
       license_file: jupyter-lsp/LICENSE
       summary: A metapackage jupyter-lsp and r-languageserver
       doc_url: https://jupyterlab-lsp.readthedocs.io
-      doc_source_url: https://github.com/jupyter-lsp/jupyterlab-lsp/blob/master/docs
+      dev_url: https://github.com/jupyter-lsp/jupyterlab-lsp
 
 
 about:
@@ -245,7 +239,7 @@ about:
   license_file: jupyterlab-lsp/LICENSE
   summary: Multi-Language Server WebSocket proxy for Jupyter Server
   doc_url: https://jupyterlab-lsp.readthedocs.io
-  doc_source_url: https://github.com/jupyter-lsp/jupyterlab-lsp/blob/master/docs
+  dev_url: https://github.com/jupyter-lsp/jupyterlab-lsp
 
 extra:
   feedstock-name: jupyter-lsp


### PR DESCRIPTION
Changes:
- new feedstock forked from conda-forge
- jupyter-lsp 2.2.0
- remove jupyterlab-lsp (will be moved to its own feedstock, to avoid circular dependencies)
- skipping meta packages were we are missing dependencies.

https://github.com/jupyter-lsp/jupyterlab-lsp/tree/v5.0.0/python_packages/jupyter_lsp
https://pypi.org/project/jupyter-lsp/2.2.0/#files <-- the actual source
